### PR TITLE
remove dependency on deprecated pkg_resources package

### DIFF
--- a/c8y_api/__init__.py
+++ b/c8y_api/__init__.py
@@ -4,14 +4,11 @@
 # Use, reproduction, transfer, publication or disclosure is prohibited except
 # as specifically provided for in your License Agreement with Software AG.
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version
 
 from c8y_api._base_api import ProcessingMode, CumulocityRestApi
 from c8y_api._main_api import CumulocityApi
 from c8y_api._registry_api import CumulocityDeviceRegistry
 from c8y_api._auth import HTTPBasicAuth, HTTPBearerAuth
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass
+__version__ = version(__name__)


### PR DESCRIPTION
Allow installation in python 3.12 by removing the usage of `pkg_resources`. `pkg_resources` is no longer installed by default from python 3.12.

Below shows the exception when trying to use the module with python 3.12.

```
ImportError: Failed to import test module: tests.test_utils
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/unittest/loader.py", line [39](https://github.com/thin-edge/c8y-test-core/actions/runs/11577220897/job/32228072709?pr=21#step:6:40)6, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/unittest/loader.py", line 339, in _get_module_from_name
    __import__(name)
  File "/home/runner/work/c8y-test-core/c8y-test-core/tests/test_utils.py", line 4, in <module>
    from c8y_test_core.utils import to_csv
  File "/home/runner/work/c8y-test-core/c8y-test-core/c8y_test_core/utils.py", line 10, in <module>
    from c8y_api.model._base import CumulocityObject
  File "/home/runner/work/c8y-test-core/c8y-test-core/.venv/lib/python3.12/site-packages/c8y_api/__init__.py", line 7, in <module>
    from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'
```