### PR TITLE
Feature/tuple parsing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Updated `as_tuple` for  complex objects as well as the `as_tuples` parameter for `select`
+  and `get_all` functions to work with strings or 2-tuples. The use of a dictionary
+  was removed as dictionaries don't define an order.
+* Added `as_tuples` parameter to the Measurements API `select` and `get_all` functions.
 * Adding `c8y_tk.analytics` package with `to_numpy`, `to_series` and `to_data_frame` functions to
   ease incorporating Cumulocity data into standard analytics pipelines.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added code coverage reporting to `test` target for _invoke_.
 * Updated `as_tuple` for  complex objects as well as the `as_tuples` parameter for `select`
   and `get_all` functions to work with strings or 2-tuples. The use of a dictionary
   was removed as dictionaries don't define an order.

--- a/c8y_api/model/_base.py
+++ b/c8y_api/model/_base.py
@@ -525,11 +525,16 @@ class ComplexObject(SimpleObject):
         segments = path.split('.')
         value = self
         for segment in segments:
-            if segment in value:
+            # try to drill down (assuming dict-like)
+            try:
                 value = value[segment]
                 continue
+            except (KeyError, TypeError):
+                pass
+            # if the segment is an actual attribute it should be the target
             if hasattr(value, segment):
                 return value.__getattribute__(segment)
+            # otherwise use the default
             return default
         return value
 

--- a/c8y_api/model/_parser.py
+++ b/c8y_api/model/_parser.py
@@ -5,7 +5,41 @@ from __future__ import annotations
 from typing import Set
 
 from c8y_api.model._base import ComplexObject
+from c8y_api.model._util import _StringUtil
 
+
+def as_tuples(json_data, *path: str | tuple):
+    """Parse a JSON structure as tuples from paths.
+
+    Args:
+        json_data (dict):  A JSON structure as Python dict
+        path (*str|tuple):  Path(s) to extract from
+            the structure; Use dots to separate JSON levels; Arrays are not
+            supported.
+
+    Mote: This function automatically converts path segments from
+    Python snake_case to pascalCase, e.g. `creation_time` will match
+    both `creation_time` and `creationTime` fields.
+
+    Returns:
+        A tuple with `len(path)` elements containing the values as-is defined
+        in the JSON structure; an invalid path will result in None.
+    """
+    def resolve(segments, default=None):
+        json_level = json_data
+        for segment in segments[:-1]:
+            if segment in json_level:
+                json_level = json_level[segment]
+                continue
+            pascal_segment = _StringUtil.to_pascal_case(segment)
+            if pascal_segment in json_level:
+                json_level = json_level[pascal_segment]
+                continue
+            return default
+        return json_level.get(segments[-1], json_level.get(_StringUtil.to_pascal_case(segments[-1]), default))
+
+    # each p in path(s) can be a string or a tuple
+    return tuple(resolve(p[0].split('.'), p[1]) if isinstance(p, tuple) else resolve(p.split('.')) for p in path )
 
 class SimpleObjectParser(object):
     """A parser for simple (without fragments) Cumulocity database objects.

--- a/c8y_api/model/alarms.py
+++ b/c8y_api/model/alarms.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import List, Generator, Any
+from typing import List, Generator
 
 from c8y_api._base_api import CumulocityRestApi
-from c8y_api.model._base import CumulocityResource, SimpleObject, ComplexObject, get_all_by_path
-from c8y_api.model._parser import ComplexObjectParser
+from c8y_api.model._base import CumulocityResource, SimpleObject, ComplexObject
+from c8y_api.model._parser import as_tuples as parse_as_tuples, ComplexObjectParser
 from c8y_api.model._util import _DateUtil
 
 
@@ -255,7 +255,7 @@ class Alarms(CumulocityResource):
                reverse: bool = False, limit: int = None,
                with_source_assets: bool = None, with_source_devices: bool = None,
                page_size: int = 1000, page_number: int = None,
-               as_tuples: list[str] | dict[str, Any] = None,
+               as_tuples: str | tuple | list[str | tuple] = None,
                **kwargs) -> Generator[Alarm]:
         """Query the database for alarms and iterate over the results.
 
@@ -307,10 +307,10 @@ class Alarms(CumulocityResource):
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
                 automatic follow-up page retrieval.
-            as_tuples: (list[str] or dict[str, Any]):  Don't parse Alarms, but
-                extract the values at certain JSON paths as tuples; If the
-                path is not defined in a result, None is used; Specify a
-                dictionary to define proper default values for each path.
+            as_tuples: (*str|tuple):  Don't parse objects, but directly extract
+                the values at certain JSON paths as tuples; If the path is not
+                defined in a result, None is used; Specify a tuple to define
+                a proper default value for each path.
 
         Returns:
             Generator of Alarm objects
@@ -333,7 +333,8 @@ class Alarms(CumulocityResource):
             base_query,
             page_number,
             limit,
-            Alarm.from_json if not as_tuples else (lambda x: get_all_by_path(x, as_tuples)))
+            Alarm.from_json if not as_tuples else
+            lambda x: parse_as_tuples(x, *([as_tuples] if isinstance(as_tuples, str) else as_tuples)))
 
     def get_all(
             self,
@@ -350,7 +351,7 @@ class Alarms(CumulocityResource):
             with_source_assets: bool = None, with_source_devices: bool = None,
             reverse: bool = False, limit: int = None,
             page_size: int = 1000, page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> List[Alarm]:
         """Query the database for alarms and return the results as list.
 

--- a/c8y_api/model/events.py
+++ b/c8y_api/model/events.py
@@ -6,11 +6,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Generator, List, BinaryIO, Any
+from typing import Generator, List, BinaryIO
 
 from c8y_api._base_api import CumulocityRestApi
-from c8y_api.model._base import CumulocityResource, SimpleObject, ComplexObject, get_all_by_path
-from c8y_api.model._parser import ComplexObjectParser
+from c8y_api.model._base import CumulocityResource, SimpleObject, ComplexObject
+from c8y_api.model._parser import as_tuples as parse_as_tuples, ComplexObjectParser
 from c8y_api.model._util import _DateUtil
 
 
@@ -264,7 +264,7 @@ class Events(CumulocityResource):
                reverse: bool = False, limit: int = None,
                with_source_assets: bool = None, with_source_devices: bool = None,
                page_size: int = 1000, page_number: int = None,
-               as_tuples: list[str] | dict[str, Any] = None,
+               as_tuples: str | tuple | list[str|tuple] = None,
                **kwargs) -> Generator[Event]:
         """Query the database for events and iterate over the results.
 
@@ -315,10 +315,10 @@ class Events(CumulocityResource):
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
                 automatic follow-up page retrieval.
-            as_tuples: (list[str] or dict[str, Any]):  Don't parse Events, but
-                extract the values at certain JSON paths as tuples; If the
-                path is not defined in a result, None is used; Specify a
-                dictionary to define proper default values for each path.
+            as_tuples: (*str|tuple):  Don't parse objects, but directly extract
+                the values at certain JSON paths as tuples; If the path is not
+                defined in a result, None is used; Specify a tuple to define
+                a proper default value for each path.
 
         Returns:
             Generator for Event objects
@@ -344,7 +344,8 @@ class Events(CumulocityResource):
             base_query,
             page_number,
             limit,
-            Event.from_json if not as_tuples else (lambda x: get_all_by_path(x, as_tuples)))
+            Event.from_json if not as_tuples else
+            lambda x: parse_as_tuples(x, *([as_tuples] if isinstance(as_tuples, str) else as_tuples)))
 
     def get_all(
             self,
@@ -361,7 +362,7 @@ class Events(CumulocityResource):
             reverse: bool = False, limit: int = None,
             with_source_assets: bool = None, with_source_devices: bool = None,
             page_size: int = 1000, page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> List[Event]:
         """Query the database for events and return the results as list.
 

--- a/c8y_api/model/inventory.py
+++ b/c8y_api/model/inventory.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from typing import Any, Generator, List
 
-from c8y_api.model._base import CumulocityResource, get_all_by_path
+from c8y_api.model._base import CumulocityResource
+from c8y_api.model._parser import as_tuples as parse_as_tuples
 from c8y_api.model._util import _QueryUtil
 from c8y_api.model.managedobjects import ManagedObjectUtil, ManagedObject, Device, Availability, DeviceGroup
 
@@ -61,7 +62,7 @@ class Inventory(CumulocityResource):
             reverse: bool = None,
             limit: int = None,
             page_size: int = 1000,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> List[ManagedObject]:
         """ Query the database for managed objects and return the results
         as list.
@@ -156,7 +157,7 @@ class Inventory(CumulocityResource):
             limit: int = None,
             page_size: int = 1000,
             page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> Generator[ManagedObject]:
         """ Query the database for managed objects and iterate over the
         results.
@@ -208,10 +209,10 @@ class Inventory(CumulocityResource):
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
                 automatic follow-up page retrieval.
-            as_tuples: (list[str] or dict[str, Any]):  Don't parse ManagedObjects,
-                but extract the values at certain JSON paths as tuples; If the path
-                is not defined in a result, None is used; Specify a dictionary to
-                define proper default values for each path.
+            as_tuples: (*str|tuple):  Don't parse objects, but directly extract
+                the values at certain JSON paths as tuples; If the path is not
+                defined in a result, None is used; Specify a tuple to define
+                a proper default value for each path.
 
         Returns:
             Generator for ManagedObject instances
@@ -351,7 +352,8 @@ class Inventory(CumulocityResource):
             base_query,
             page_number,
             limit,
-            parse_fun if not as_tuples else (lambda x: get_all_by_path(x, as_tuples)))
+            parse_fun if not as_tuples else
+            lambda x: parse_as_tuples(x, *([as_tuples] if isinstance(as_tuples, str) else as_tuples)))
 
     def create(self, *objects: ManagedObject):
         """Create managed objects within the database.
@@ -501,7 +503,7 @@ class DeviceInventory(Inventory):
             limit: int = None,
             page_size: int = 100,
             page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs,) -> Generator[Device]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Query the database for devices and iterate over the results.
@@ -556,10 +558,10 @@ class DeviceInventory(Inventory):
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
                 automatic follow-up page retrieval.
-            as_tuples: (list[str] or dict[str, Any]):  Don't parse Device objects,
-                but extract the values at certain JSON paths as tuples; If the path
-                is not defined in a result, None is used; Specify a dictionary to
-                define proper default values for each path.
+            as_tuples: (*str|tuple):  Don't parse objects, but directly extract
+                the values at certain JSON paths as tuples; If the path is not
+                defined in a result, None is used; Specify a tuple to define
+                a proper default value for each path.
 
         Returns:
             Generator for Device objects
@@ -614,7 +616,7 @@ class DeviceInventory(Inventory):
             limit: int = None,
             page_size: int = 100,
             page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> List[Device]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Query the database for devices and return the results as list.
@@ -754,7 +756,7 @@ class DeviceGroupInventory(Inventory):
             limit: int = None,
             page_size: int = 100,
             page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs) -> Generator[DeviceGroup]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Select device groups by various parameters.
@@ -812,11 +814,10 @@ class DeviceGroupInventory(Inventory):
                 parsed in one chunk). This is a performance related setting.
             page_number (int): Pull a specific page; this effectively disables
                 automatic follow-up page retrieval.
-            as_tuples: (list[str] or dict[str, Any]):  Don't parse DeviceGroup
-                objects, but extract the values at certain JSON paths as
-                tuples; If the path is not defined in a result, None is used;
-                Specify a dictionary to define proper default values for each
-                path.
+            as_tuples: (*str|tuple):  Don't parse objects, but directly extract
+                the values at certain JSON paths as tuples; If the path is not
+                defined in a result, None is used; Specify a tuple to define
+                a proper default value for each path.
 
         Returns:
             Generator of DeviceGroup instances
@@ -923,7 +924,7 @@ class DeviceGroupInventory(Inventory):
             limit: int = None,
             page_size: int = 100,
             page_number: int = None,
-            as_tuples: list[str] | dict[str, Any] = None,
+            as_tuples: str | tuple | list[str|tuple] = None,
             **kwargs ) -> List[DeviceGroup]:
         # pylint: disable=arguments-differ, arguments-renamed
         """ Select managed objects by various parameters.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests
 Deprecated
 pytest
 pytest-asyncio
+pytest-cov
 responses
 python-dotenv
 invoke

--- a/tasks.py
+++ b/tasks.py
@@ -56,10 +56,13 @@ def lint(c, scope='all'):
     'scope': "Which tests to run, e.g. 'tests.model'"
              "Default: 'tests'",
     'python': ("Whether to run tests within a docker container and which"
-               "Python version to use - 3.7 or 3.11. Default: None")
+               "Python version to use - 3.7 or 3.11. Default: None"),
+    'coverage': "Whether to include coverage analysis.",
 })
-def test(c, scope='tests', python=None):
+def test(c, scope='tests', python=None, coverage=False):
     """Run test."""
+
+    cov_option = '--cov=c8y_api' if coverage else ''
 
     docker_name = None
     if python == '3.7':
@@ -74,11 +77,14 @@ def test(c, scope='tests', python=None):
         cmd_run = (f'docker run --rm -it -v $(pwd):/code {docker_name} '
                    'bash -c "cd /code '
                    '&& export PYTHONPATH="/code:${PYTHONPATH}" '
-                   f'&& pytest -W ignore::DeprecationWarning {scope}"')
+                   f'&& pytest -W ignore::DeprecationWarning {cov_option} {scope}"')
         print(f"Executing '{cmd_run}' ...")
         c.run(cmd_run, pty=True)
     else:
-        c.run(f"pytest -W ignore::DeprecationWarning {scope}")
+        c.run(f"pytest -W ignore::DeprecationWarning {cov_option} {scope}")
+
+    if coverage:
+        c.run(f"coverage html -d coverage --data-file .coverage")
 
 
 @task

--- a/tests/model/test_alarms.py
+++ b/tests/model/test_alarms.py
@@ -100,7 +100,7 @@ def test_select_as_tuples():
     ]
 
     api.c8y.get = Mock(side_effect=[{'alarms': jsons}, {'alarms': []}])
-    result = api.get_all(as_tuples={'type': None, 'text': None, 'test_Fragment.key': None, 'test_Fragment.key2': '-'})
+    result = api.get_all(as_tuples=['type', 'text', 'test_Fragment.key', ('test_Fragment.key2', '-')])
     assert result == [
         ('type1', 'text1', 'value1', 'value2'),
         ('type2', 'text2', 'value2', '-'),

--- a/tests/model/test_events.py
+++ b/tests/model/test_events.py
@@ -131,7 +131,7 @@ def test_select_as_tuples():
     ]
 
     api.c8y.get = Mock(side_effect=[{'events': jsons}, {'events': []}])
-    result = api.get_all(as_tuples={'type': None, 'text': None, 'test_Fragment.key': None, 'test_Fragment.key2': '-'})
+    result = api.get_all(as_tuples=['type', 'text', 'test_Fragment.key', ('test_Fragment.key2', '-')])
     assert result == [
         ('type1', 'text1', 'value1', 'value2'),
         ('type2', 'text2', 'value2', '-'),

--- a/tests/model/test_inventory.py
+++ b/tests/model/test_inventory.py
@@ -111,8 +111,7 @@ def test_select_as_tuples(inventory_class):
     ]
 
     c8y.get = Mock(side_effect=[{'managedObjects': data}, {'managedObjects': []}])
-    result = inventory.get_all(as_tuples={'name': None, 'type': None,
-                                          'test_Fragment.key': None, 'test_Fragment.key2': '-'})
+    result = inventory.get_all(as_tuples=['name', 'type', 'test_Fragment.key', ('test_Fragment.key2', '-')])
     assert result == [
         ('n1', 't1', 'value1', 'value2'),
         ('n2', 't2', 'value2', '-'),

--- a/tests/model/test_measurements.py
+++ b/tests/model/test_measurements.py
@@ -41,6 +41,37 @@ def test_measurement_parsing():
     assert m.to_full_json() == expected_full_json
 
 
+def test_measurement_parsing_as_tuples():
+    """Verify that parsing Measurements directly as tuples works as expected."""
+    measurements_json = {
+        'measurements': [
+            {
+                'id': '12345',
+                'self': 'https://...',
+                'type': 'c8y_Measurement',
+                'source': {'id': '54321', 'self': 'https://...'},
+                'time': '2020-31-12T22:33:44,567Z',
+                'c8y_Measurement': {'c8y_temperature': {'unit': 'x', 'value': 12.3}}
+            }, {
+                'id': '12346',
+                'self': 'https://...',
+                'type': 'c8y_Measurement',
+                'source': {'id': '54321', 'self': 'https://...'},
+                'time': '2020-31-12T22:33:44,568Z',
+                'c8y_Measurement': {'c8y_temperature': {'unit': 'x', 'value': 34.5}}
+            }
+        ]
+    }
+    c8y = CumulocityApi(base_url='base', tenant_id='t12345', username='user', password='pass')
+    c8y.get = Mock(side_effect=(measurements_json, {'measurements': []}))
+    result = c8y.measurements.get_all(as_tuples=['id', 'type', 'time', 'c8y_Measurement.c8y_temperature.value'])
+
+    assert result == [
+        ('12345', 'c8y_Measurement', '2020-31-12T22:33:44,567Z', 12.3),
+        ('12346', 'c8y_Measurement', '2020-31-12T22:33:44,568Z', 34.5),
+    ]
+
+
 def isolate_call_url(fun, **kwargs):
     """Call an Applications API function and isolate the request URL for further assertions."""
     c8y = CumulocityApi(base_url='some.host.com', tenant_id='t123', username='user', password='pass')


### PR DESCRIPTION
* Added code coverage reporting to `test` target for _invoke_.
* Updated `as_tuple` for  complex objects as well as the `as_tuples` parameter for `select`
  and `get_all` functions to work with strings or 2-tuples. The use of a dictionary
  was removed as dictionaries don't define an order.
* Added `as_tuples` parameter to the Measurements API `select` and `get_all` functions.
* Adding `c8y_tk.analytics` package with `to_numpy`, `to_series` and `to_data_frame` functions to
  ease incorporating Cumulocity data into standard analytics pipelines.
